### PR TITLE
Fix OpenDeck settings popup

### DIFF
--- a/pi/pi.js
+++ b/pi/pi.js
@@ -276,7 +276,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const settingsButton = document.getElementById('settings');
     if (settingsButton) {
         settingsButton.addEventListener('click', function() {
-            window.setupPopup = window.open('setup.html', 'iCal Settings', 'width=600,height=700');
+            window.setupPopup = window.open('setup.html');
         });
     }
 });


### PR DESCRIPTION
## Summary
- Open the setup page without a named window target so OpenDeck keeps it in the property inspector iframe flow.

## Details
OpenDeck treats named `window.open` targets as external URLs. That prevents the setup page from retaining access to the property inspector opener and websocket, which makes saving settings fail with `Unable to communicate with plugin`.

Fixes #32.

## Tests
- `npm test`
- `npm run build`
